### PR TITLE
Replace gost with shadowsocks-go

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -3,8 +3,8 @@ name: Build and publish Docker image
 on:
   workflow_dispatch:
     inputs:
-      GOST_VERSION:
-        description: "Version of gost. If empty, the latest version will be used."
+      SSGO_VERSION:
+        description: "Version of shadowsocks-go. If empty, the latest version will be used."
         required: false
         type: string
 
@@ -30,21 +30,21 @@ jobs:
           username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Get gost version
-        id: get-gost-version
+      - name: Get shadowsocks-go version
+        id: get-ssgo-version
         run: |
-          if [ -z "${{ github.event.inputs.GOST_VERSION }}" ]; then
-            echo "GOST_VERSION=$(curl -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -s https://api.github.com/repos/ginuerzh/gost/releases/latest | jq -r '.tag_name' | cut -c 2-)" >> "$GITHUB_OUTPUT"
+          if [ -z "${{ github.event.inputs.SSGO_VERSION }}" ]; then
+            echo "SSGO_VERSION=$(curl -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -s https://api.github.com/repos/database64128/shadowsocks-go/releases/latest | jq -r '.tag_name' | cut -c 2-)" >> "$GITHUB_OUTPUT"
           else
-            echo "GOST_VERSION=${{ github.event.inputs.GOST_VERSION }}" >> "$GITHUB_OUTPUT"
+            echo "SSGO_VERSION=${{ github.event.inputs.SSGO_VERSION }}" >> "$GITHUB_OUTPUT"
           fi
 
-      # gost version must be <number>.<number>.<number>
-      - name: Verify gost version
-        id: verify-gost-version
+      # shadowsocks-go version must be <number>.<number>.<number>
+      - name: Verify shadowsocks-go version
+        id: verify-ssgo-version
         run: |
-          if [[ ! "${{ steps.get-gost-version.outputs.GOST_VERSION }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Invalid gost version: ${{ steps.get-gost-version.outputs.GOST_VERSION }}"
+          if [[ ! "${{ steps.get-ssgo-version.outputs.SSGO_VERSION }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid shadowsocks-go version: ${{ steps.get-ssgo-version.outputs.SSGO_VERSION }}"
             exit 1
           fi
 
@@ -60,7 +60,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           build-args: |
-            GOST_VERSION=${{ steps.get-gost-version.outputs.GOST_VERSION }}
+            SSGO_VERSION=${{ steps.get-ssgo-version.outputs.SSGO_VERSION }}
             WARP_VERSION=${{ steps.get-warp-client-version.outputs.WARP_VERSION }}
             COMMIT_SHA=${{ github.sha }}
           context: .
@@ -68,5 +68,5 @@ jobs:
           push: true
           tags: |
             ${{ vars.REGISTRY }}/${{ vars.IMAGE_NAME }}:latest
-            ${{ vars.REGISTRY }}/${{ vars.IMAGE_NAME }}:${{ steps.get-warp-client-version.outputs.WARP_VERSION }}-${{ steps.get-gost-version.outputs.GOST_VERSION }}
-            ${{ vars.REGISTRY }}/${{ vars.IMAGE_NAME }}:${{ steps.get-warp-client-version.outputs.WARP_VERSION }}-${{ steps.get-gost-version.outputs.GOST_VERSION }}-${{ github.sha }}
+            ${{ vars.REGISTRY }}/${{ vars.IMAGE_NAME }}:${{ steps.get-warp-client-version.outputs.WARP_VERSION }}-${{ steps.get-ssgo-version.outputs.SSGO_VERSION }}
+            ${{ vars.REGISTRY }}/${{ vars.IMAGE_NAME }}:${{ steps.get-warp-client-version.outputs.WARP_VERSION }}-${{ steps.get-ssgo-version.outputs.SSGO_VERSION }}-${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
 FROM ubuntu:22.04
 
 ARG WARP_VERSION
-ARG GOST_VERSION
+ARG SSGO_VERSION
 ARG COMMIT_SHA
 ARG TARGETPLATFORM
 
 LABEL org.opencontainers.image.authors="cmj2002"
 LABEL org.opencontainers.image.url="https://github.com/cmj2002/warp-docker"
 LABEL WARP_VERSION=${WARP_VERSION}
-LABEL GOST_VERSION=${GOST_VERSION}
+LABEL SSGO_VERSION=${SSGO_VERSION}
 LABEL COMMIT_SHA=${COMMIT_SHA}
 
 COPY entrypoint.sh /entrypoint.sh
 COPY ./healthcheck /healthcheck
+COPY ./config/shadowsocks-go.json /etc/shadowsocks-go/config.json
 
 # install dependencies
 RUN case ${TARGETPLATFORM} in \
@@ -20,38 +21,25 @@ RUN case ${TARGETPLATFORM} in \
       "linux/arm64")   export ARCH="armv8" ;; \
       *) echo "Unsupported TARGETPLATFORM: ${TARGETPLATFORM}" && exit 1 ;; \
     esac && \
-    echo "Building for ${TARGETPLATFORM} with GOST ${GOST_VERSION}" &&\
+    echo "Building for ${TARGETPLATFORM} with shadowsocks-go ${SSGO_VERSION}" &&\
     apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y curl gnupg lsb-release sudo jq ipcalc && \
+    apt-get install -y curl gnupg lsb-release sudo jq ipcalc zstd && \
     curl https://pkg.cloudflareclient.com/pubkey.gpg | gpg --yes --dearmor --output /usr/share/keyrings/cloudflare-warp-archive-keyring.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/cloudflare-warp-archive-keyring.gpg] https://pkg.cloudflareclient.com/ $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/cloudflare-client.list && \
     apt-get update && \
     apt-get install -y cloudflare-warp && \
     apt-get clean && \
     apt-get autoremove -y && \
-    MAJOR_VERSION=$(echo ${GOST_VERSION} | cut -d. -f1) && \
-    MINOR_VERSION=$(echo ${GOST_VERSION} | cut -d. -f2) && \
-    # detect if version >= 2.12.0, which uses new filename syntax
-    if [ "${MAJOR_VERSION}" -ge 3 ] || [ "${MAJOR_VERSION}" -eq 2 -a "${MINOR_VERSION}" -ge 12 ]; then \
-      NAME_SYNTAX="new" && \
-      if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
-        ARCH="arm64"; \
-      fi && \
-      FILE_NAME="gost_${GOST_VERSION}_linux_${ARCH}.tar.gz"; \
-    else \
-      NAME_SYNTAX="legacy" && \
-      FILE_NAME="gost-linux-${ARCH}-${GOST_VERSION}.gz"; \
-    fi && \
+    case ${TARGETPLATFORM} in \
+      "linux/amd64") FILE_ARCH="x86-64-v3" ;; \
+      "linux/arm64") FILE_ARCH="arm64" ;; \
+    esac && \
+    FILE_NAME="shadowsocks-go-v${SSGO_VERSION}-linux-${FILE_ARCH}.tar.zst" && \
     echo "File name: ${FILE_NAME}" && \
-    curl -LO https://github.com/ginuerzh/gost/releases/download/v${GOST_VERSION}/${FILE_NAME} && \
-    if [ "${NAME_SYNTAX}" = "new" ]; then \
-      tar -xzf ${FILE_NAME} -C /usr/bin/ gost; \
-    else \
-      gunzip ${FILE_NAME} && \
-      mv gost-linux-${ARCH}-${GOST_VERSION} /usr/bin/gost; \
-    fi && \
-    chmod +x /usr/bin/gost && \
+    curl -LO https://github.com/database64128/shadowsocks-go/releases/download/v${SSGO_VERSION}/${FILE_NAME} && \
+    tar --use-compress-program=unzstd -xf ${FILE_NAME} -C /usr/bin/ shadowsocks-go && \
+    chmod +x /usr/bin/shadowsocks-go && \
     chmod +x /entrypoint.sh && \
     chmod +x /healthcheck/index.sh && \
     useradd -m -s /bin/bash warp && \
@@ -63,7 +51,7 @@ USER warp
 RUN mkdir -p /home/warp/.local/share/warp && \
     echo -n 'yes' > /home/warp/.local/share/warp/accepted-tos.txt
 
-ENV GOST_ARGS="-L :1080"
+ENV SSGO_ARGS="--confPath /etc/shadowsocks-go/config.json"
 ENV WARP_SLEEP=2
 ENV REGISTER_WHEN_MDM_EXISTS=
 ENV WARP_LICENSE_KEY=

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/caomingjun/warp)](https://hub.docker.com/r/caomingjun/warp)
 ![WARP version in latest image](https://img.shields.io/endpoint?url=https%3A%2F%2Fapi.caomingjun.com%2Fdockerhub-label%3Frepo%3Dcaomingjun%2Fwarp%26label%3DWARP_VERSION%26display%3DWARP%2520in%2520image)
-![GOST version in latest image](https://img.shields.io/endpoint?url=https%3A%2F%2Fapi.caomingjun.com%2Fdockerhub-label%3Frepo%3Dcaomingjun%2Fwarp%26label%3DGOST_VERSION%26display%3DGOST%2520in%2520image)
+![shadowsocks-go version in latest image](https://img.shields.io/endpoint?url=https%3A%2F%2Fapi.caomingjun.com%2Fdockerhub-label%3Frepo%3Dcaomingjun%2Fwarp%26label%3DSSGO_VERSION%26display%3Dshadowsocks-go%2520in%2520image)
 
 Run official [Cloudflare WARP](https://1.1.1.1/) client in Docker.
 
 > [!NOTE]
-> Cannot guarantee that the [GOST](https://github.com/ginuerzh/gost) and WARP client contained in the image are the latest versions. If necessary, please [build your own image](#build).
+> Cannot guarantee that the [shadowsocks-go](https://github.com/database64128/shadowsocks-go) and WARP client contained in the image are the latest versions. If necessary, please [build your own image](#build).
 
 ## Usage
 
@@ -63,7 +63,7 @@ You can configure the container through the following environment variables:
 
 - `WARP_SLEEP`: The time to wait for the WARP daemon to start, in seconds. The default is 2 seconds. If the time is too short, it may cause the WARP daemon to not start before using the proxy, resulting in the proxy not working properly. If the time is too long, it may cause the container to take too long to start. If your server has poor performance, you can increase this value appropriately.
 - `WARP_LICENSE_KEY`: The license key of the WARP client, which is optional. If you have subscribed to WARP+ service, you can fill in the key in this environment variable. If you have not subscribed to WARP+ service, you can ignore this environment variable.
-- `GOST_ARGS`: The arguments passed to GOST. The default is `-L :1080`, which means to listen on port 1080 in the container at the same time through HTTP and SOCKS5 protocols. If you want to have UDP support or use advanced features provided by other protocols, you can modify this parameter. For more information, refer to [GOST documentation](https://v2.gost.run/en/). If you modify the port number, you may also need to modify the port mapping in the `docker-compose.yml`.
+- `SSGO_ARGS`: The arguments passed to shadowsocks-go. The default is `--confPath /etc/shadowsocks-go/config.json`, which provides HTTP and SOCKS5 proxy on port 1080. If you need to change the port or use advanced features, mount your own config file and modify this parameter. See the [shadowsocks-go documentation](https://github.com/database64128/shadowsocks-go) for details. If you modify the port number, you may also need to adjust the port mapping in `docker-compose.yml`.
 - `REGISTER_WHEN_MDM_EXISTS`: If set, will register consumer account (WARP or WARP+, in contrast to Zero Trust) even when `mdm.xml` exists. You usually don't need this, as `mdm.xml` are usually used for Zero Trust. However, some users may want to adjust advanced settings in `mdm.xml` while still using consumer account.
 - `BETA_FIX_HOST_CONNECTIVITY`: If set, will add checks for host connectivity into healthchecks and automatically fix it if necessary. See [host connectivity issue](docs/host-connectivity.md) for more information.
 - `WARP_ENABLE_NAT`: If set, will work as warp mode and turn NAT on. You can route L3 traffic through `warp-docker` to Warp. See [nat gateway](docs/nat-gateway.md) for more information.
@@ -74,12 +74,12 @@ For advanced usage or configurations, see [documentation](docs/README.md).
 
 ### Use other versions
 
-The tag of docker image is in the format of `{WARP_VERSION}-{GOST_VERSION}`, for example, `2023.10.120-2.11.5` means that the WARP client version is `2023.10.120` and the GOST version is `2.11.5`. If you want to use other versions, you can specify the tag in the `docker-compose.yml`.
+The tag of docker image is in the format of `{WARP_VERSION}-{SSGO_VERSION}`, for example, `2023.10.120-1.14.0` means that the WARP client version is `2023.10.120` and the shadowsocks-go version is `1.14.0`. If you want to use other versions, you can specify the tag in the `docker-compose.yml`.
 
 You can also use the `latest` tag to use the latest version of the image.
 
 > [!NOTE]
-> You can access the image built by a certain commit by using the tag `{WARP_VERSION}-{GOST_VERSION}-{COMMIT_SHA}`. Not all commits have images built.
+> You can access the image built by a certain commit by using the tag `{WARP_VERSION}-{SSGO_VERSION}-{COMMIT_SHA}`. Not all commits have images built.
 
 > [!NOTE]
 > Not all version combinations are available. Do check [the list of tags in Docker Hub](https://hub.docker.com/r/caomingjun/warp/tags) before you use one. If the version you want is not available, you can [build your own image](#build).
@@ -96,7 +96,7 @@ You can use Github Actions to build the image yourself.
    4. secret `DOCKER_PASSWORD`: generate a token in Docker Hub and fill in the token
 3. Manually trigger the workflow `Build and push image` in the Actions tab.
 
-This will build the image with the latest version of WARP client and GOST and push it to the specified registry. You can also specify the version of GOST by giving input to the workflow. Building image with custom WARP client version is not supported yet.
+This will build the image with the latest version of WARP client and shadowsocks-go and push it to the specified registry. You can also specify the version of shadowsocks-go by giving input to the workflow. Building image with custom WARP client version is not supported yet.
 
 If you want to build the image locally, you can use [`.github/workflows/build-publish.yml`](.github/workflows/build-publish.yml) as a reference.
 
@@ -104,7 +104,7 @@ If you want to build the image locally, you can use [`.github/workflows/build-pu
 
 ### Proxying UDP or even ICMP traffic
 
-The default `GOST_ARGS` is `-L :1080`, which provides HTTP and SOCKS5 proxy. If you want to proxy UDP or even ICMP traffic, you need to change the `GOST_ARGS`. Read the [GOST documentation](https://v2.gost.run/en/) for more information. If you modify the port number, you may also need to modify the port mapping in the `docker-compose.yml`.
+The default `SSGO_ARGS` uses `/etc/shadowsocks-go/config.json`, which provides HTTP and SOCKS5 proxy on port 1080. If you want to proxy UDP or even ICMP traffic or change the port, edit the config file and set `SSGO_ARGS` accordingly. See the [shadowsocks-go documentation](https://github.com/database64128/shadowsocks-go) for more information. If you modify the port number, you may also need to modify the port mapping in the `docker-compose.yml`.
 
 ### How to connect from another container
 

--- a/config/shadowsocks-go.json
+++ b/config/shadowsocks-go.json
@@ -1,0 +1,25 @@
+{
+    "servers": [
+        {
+            "name": "socks5",
+            "protocol": "socks5",
+            "tcpListeners": [
+                {"network": "tcp", "address": ":1080", "reusePort": true}
+            ],
+            "udpListeners": [
+                {"network": "udp", "address": ":1080", "reusePort": true}
+            ]
+        },
+        {
+            "name": "http",
+            "protocol": "http",
+            "tcpListeners": [
+                {"network": "tcp", "address": ":1080", "reusePort": true}
+            ]
+        }
+    ],
+    "router": {
+        "defaultTCPClientName": "direct",
+        "defaultUDPClientName": "direct"
+    }
+}

--- a/docs/proxy-mode.md
+++ b/docs/proxy-mode.md
@@ -23,7 +23,7 @@ exit 0
 ```
 
 Update the `docker-compose.yml` file:
-1. set env `GOST_ARGS` to `-L :1080 -F=127.0.0.1:40000`
+1. set env `SSGO_ARGS` to `--confPath /etc/shadowsocks-go/config.json`
 2. mount new healthcheck to `/healthcheck/connected-to-warp.sh`:
 
 For example, the default `docker-compose.yml` file will be changed to:
@@ -43,7 +43,7 @@ services:
       - "1080:1080"
     environment:
       - WARP_SLEEP=2
-      - GOST_ARGS=-L :1080 -F=127.0.0.1:40000
+      - SSGO_ARGS=--confPath /etc/shadowsocks-go/config.json
       # - WARP_LICENSE_KEY= # optional
     cap_add:
       # Docker already have them, these are for podman users

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -76,4 +76,4 @@ if [ -n "$WARP_ENABLE_NAT" ]; then
 fi
 
 # start the proxy
-gost $GOST_ARGS
+shadowsocks-go $SSGO_ARGS


### PR DESCRIPTION
## Summary
- drop gost in favour of shadowsocks-go
- add default shadowsocks-go config
- run shadowsocks-go in entrypoint script
- support SSGO version in build workflow and Dockerfile
- document new proxy settings

## Testing
- `bash -n entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_e_6847c54f6960832090993e76466cdefb